### PR TITLE
Modified peer classes to avoid nesting and attribute copying.

### DIFF
--- a/src/lossy_peer.py
+++ b/src/lossy_peer.py
@@ -29,22 +29,9 @@ class Lossy_Peer(Peer_FNS):
     def __init__(self, peer):
         # {{{
 
-        #Peer_FNS.__init__(self, peer)
-
         sys.stdout.write(Color.yellow)
         _print_("Lossy Peer")
         sys.stdout.write(Color.none)
-
-        threading.Thread.__init__(self)
-
-        self.splitter_socket = peer.splitter_socket
-        self.player_socket = peer.player_socket
-        self.buffer_size = peer.buffer_size
-        self.chunk_format_string = peer.chunk_format_string
-        self.splitter = peer.splitter
-        self.chunk_size = peer.chunk_size
-        self.peer_list = peer.peer_list
-        self.debt = peer.debt
 
         # }}}
 

--- a/src/monitor_dbs.py
+++ b/src/monitor_dbs.py
@@ -32,20 +32,6 @@ class Monitor_DBS(Peer_DBS):
         _print_("Monitor DBS (list)")
         sys.stdout.write(Color.none)
 
-        threading.Thread.__init__(self)
-
-        self.peer_list = peer.peer_list
-        self.splitter_socket = peer.splitter_socket
-        self.buffer_size = peer.buffer_size
-        #self.chunk_format_string = peer.chunk_format_string
-        self.splitter = peer.splitter
-        self.debt = peer.debt
-        self.chunk_size = peer.chunk_size
-        self.player_socket = peer.player_socket
-        self.message_format = peer.message_format
-        self.team_socket = peer.team_socket
-        #self.extended_message_format = peer.extended_message_format
-        
         # }}}
 
     def print_the_module_name(self):

--- a/src/monitor_fns.py
+++ b/src/monitor_fns.py
@@ -30,18 +30,6 @@ class Monitor_FNS(Peer_FNS, Monitor_DBS):
         _print_("Monitor FNS")
         sys.stdout.write(Color.none)
 
-        threading.Thread.__init__(self)
-
-        self.splitter_socket = peer.splitter_socket
-        self.player_socket = peer.player_socket
-        self.buffer_size = peer.buffer_size
-        self.chunk_format_string = peer.chunk_format_string
-        self.splitter = peer.splitter
-        self.chunk_size = peer.chunk_size
-        
-        self.peer_list = peer.peer_list
-        self.debt = peer.debt
-
         # }}}
 
     def say_hello(self, node):

--- a/src/monitor_lrs.py
+++ b/src/monitor_lrs.py
@@ -28,19 +28,6 @@ class Monitor_LRS(Monitor_FNS):
         _print_("Monitor LRS")
         sys.stdout.write(Color.none)
 
-        threading.Thread.__init__(self)
-        
-        self.splitter_socket = peer.splitter_socket
-        self.splitter = peer.splitter
-        self.buffer_size = peer.buffer_size
-        #self.chunk_format_string = peer.chunk_format_string
-        self.peer_list = peer.peer_list
-        self.player_socket = peer.player_socket
-        self.chunk_size = peer.chunk_size
-        self.debt = peer.debt
-        self.team_socket = peer.team_socket
-        self.message_format = peer.message_format
-
         # }}}
 
     def receive_the_buffer_size(self):

--- a/src/peer_dbs.py
+++ b/src/peer_dbs.py
@@ -43,17 +43,6 @@ class Peer_DBS(Peer_IMS):
         _print_("Peer DBS (list)")
         sys.stdout.write(Color.none)
 
-        threading.Thread.__init__(self)
-
-        self.splitter_socket = peer.splitter_socket
-        self.player_socket = peer.player_socket
-        self.buffer_size = peer.buffer_size
-        #self.chunk_format_string = peer.message_format
-        self.splitter = peer.splitter
-        self.chunk_size = peer.chunk_size
-        self.message_format = peer.message_format
-        #self.extended_message_format = peer.message_format + "4sH"
-
         _print_("DBS: max_chunk_debt =", self.MAX_CHUNK_DEBT)
         
         # }}}

--- a/src/peer_fns.py
+++ b/src/peer_fns.py
@@ -28,18 +28,6 @@ class Peer_FNS(Peer_DBS):
         _print_("Peer FNS")
         sys.stdout.write(Color.none)
 
-        threading.Thread.__init__(self)
-
-        self.splitter_socket = peer.splitter_socket
-        self.player_socket = peer.player_socket
-        self.buffer_size = peer.buffer_size
-        self.splitter = peer.splitter
-        self.chunk_size = peer.chunk_size
-        self.peer_list = peer.peer_list
-        self.debt = peer.debt
-        self.message_format = peer.message_format
-        self.team_socket = peer.team_socket
-
         # }}}
 
     def say_hello(self, node):

--- a/src/peer_ims.py
+++ b/src/peer_ims.py
@@ -35,6 +35,20 @@ class Peer_IMS(threading.Thread):
 
     # }}}
 
+    def __new__(typ, *args, **kwargs):
+        # {{{
+
+        if len(args) == 1 and isinstance(args[0], Peer_IMS):
+            # Parameter is a peer instance; extending its class instead of nesting:
+            instance = args[0]
+            instance.__class__ = typ
+            return instance
+        else:
+            # Use default object creation
+            return object.__new__(typ, *args, **kwargs)
+
+        # }}}
+
     def __init__(self):
         # {{{
 


### PR DESCRIPTION
This commit overrides the `__new__` method in `Peer_IMS` to avoid creating several nested peer instances and copying their attributes and therefore simplifying the constructors.
The functionality of the instances is extended by setting `__class__` to the requested subclass and therefore keeping the attributes.

The constructors, i.e. the syntax of creating specialized peer instances, stays as before:
```
peer = Peer_IMS()
# ... initialize IMS peer ...
peer = Peer_DBS(peer)
```
The subclassing is happening implicitly in the `__new__` method.