### PR TITLE
Make peers connect to splitter to get their public IP.

### DIFF
--- a/src/peer_ims.py
+++ b/src/peer_ims.py
@@ -97,7 +97,7 @@ class Peer_IMS(threading.Thread):
             #my_ip = '127.0.0.1'
         else:
             s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-            s.connect(("gmail.com",80))
+            s.connect(self.splitter)
             #my_ip = socket.gethostbyname(socket.gethostname())
             my_ip = s.getsockname()[0]
             s.close()


### PR DESCRIPTION
Sometimes it might not be possible or desired for the peer to send packets to gmail.com (e.g. in a virtual machine setup where the peers don't have a direct connection to the internet).
This commit makes peers connect to the splitter IP address instead, as it has to be reachable from the peers anyway.