### PR TITLE
Split up process_next_message() to facilitate overriding.

### DIFF
--- a/src/peer_dbs.py
+++ b/src/peer_dbs.py
@@ -139,93 +139,44 @@ class Peer_DBS(Peer_IMS):
 
         # }}}
 
-    def process_next_message(self):
+    def process_message(self, message, sender):
         # {{{ Now, receive and send.
 
-        try:
-            # {{{ Receive and send
+        if len(message) == struct.calcsize(self.message_format):
+            # {{{ A video chunk has been received
 
-            message, sender = self.receive_the_next_message()
+            chunk_number, chunk = self.unpack_message(message)
+            self.chunks[chunk_number % self.buffer_size] = chunk
+            self.received_flag[chunk_number % self.buffer_size] = True
+            self.received_counter += 1
 
-            if len(message) == struct.calcsize(self.message_format):
-                # {{{ A video chunk has been received
+            if sender == self.splitter:
+                # {{{ Send the previous chunk in burst sending
+                # mode if the chunk has not been sent to all
+                # the peers of the list of peers.
 
-                chunk_number, chunk = self.unpack_message(message)
-                self.chunks[chunk_number % self.buffer_size] = chunk
-                self.received_flag[chunk_number % self.buffer_size] = True
-                self.received_counter += 1
+                # {{{ debug
 
-                if sender == self.splitter:
-                    # {{{ Send the previous chunk in burst sending
-                    # mode if the chunk has not been sent to all
-                    # the peers of the list of peers.
+                if __debug__:
+                    _print_("DBS:", self.team_socket.getsockname(), \
+                        Color.red, "<-", Color.none, chunk_number, "-", sender)
 
-                    # {{{ debug
+                # }}}
 
-                    if __debug__:
-                        _print_("DBS:", self.team_socket.getsockname(), \
-                            Color.red, "<-", Color.none, chunk_number, "-", sender)
-
-                    # }}}
-
-                    while( (self.receive_and_feed_counter < len(self.peer_list)) and (self.receive_and_feed_counter > 0) ):
-                        peer = self.peer_list[self.receive_and_feed_counter]
-                        self.team_socket.sendto(self.receive_and_feed_previous, peer)
-                        self.sendto_counter += 1
-
-                        # {{{ debug
-
-                        if __debug__:
-                            print ("DBS:", self.team_socket.getsockname(), "-",\
-                                socket.ntohs(struct.unpack(self.message_format, \
-                                                               self.receive_and_feed_previous)[0]),\
-                                Color.green, "->", Color.none, peer)
-
-                        # }}}
-
-                        self.debt[peer] += 1
-                        if self.debt[peer] > self.MAX_CHUNK_DEBT:
-                            print (Color.red, "DBS:", peer, 'removed by unsupportive (' + str(self.debt[peer]) + ' lossess)', Color.none)
-                            del self.debt[peer]
-                            self.peer_list.remove(peer)
-
-                        self.receive_and_feed_counter += 1
-
-                    self.receive_and_feed_counter = 0
-                    self.receive_and_feed_previous = message
-
-                   # }}}
-                else:
-                    # {{{ The sender is a peer
-
-                    # {{{ debug
-
-                    if __debug__:
-                        print ("DBS:", self.team_socket.getsockname(), \
-                            Color.green, "<-", Color.none, chunk_number, "-", sender)
-
-                    # }}}
-
-                    if sender not in self.peer_list:
-                        # The peer is new
-                        self.peer_list.append(sender)
-                        self.debt[sender] = 0
-                        print (Color.green, "DBS:", sender, 'added by chunk', \
-                            chunk_number, Color.none)
-                    else:
-                        self.debt[sender] -= 1
-
-                    # }}}
-
-                # {{{ A new chunk has arrived and the
-                # previous must be forwarded to next peer of the
-                # list of peers.
-                if ( self.receive_and_feed_counter < len(self.peer_list) and ( self.receive_and_feed_previous != '') ):
-                    # {{{ Send the previous chunk in congestion avoiding mode.
-
+                while( (self.receive_and_feed_counter < len(self.peer_list)) and (self.receive_and_feed_counter > 0) ):
                     peer = self.peer_list[self.receive_and_feed_counter]
                     self.team_socket.sendto(self.receive_and_feed_previous, peer)
                     self.sendto_counter += 1
+
+                    # {{{ debug
+
+                    if __debug__:
+                        print ("DBS:", self.team_socket.getsockname(), "-",\
+                            socket.ntohs(struct.unpack(self.message_format, \
+                                                           self.receive_and_feed_previous)[0]),\
+                            Color.green, "->", Color.none, peer)
+
+                    # }}}
 
                     self.debt[peer] += 1
                     if self.debt[peer] > self.MAX_CHUNK_DEBT:
@@ -233,48 +184,86 @@ class Peer_DBS(Peer_IMS):
                         del self.debt[peer]
                         self.peer_list.remove(peer)
 
-                    # {{{ debug
-
-                    if __debug__:
-                        print ("DBS:", self.team_socket.getsockname(), "-", \
-                            socket.ntohs(struct.unpack(self.message_format, self.receive_and_feed_previous)[0]),\
-                            Color.green, "->", Color.none, peer)
-
-                    # }}}
-
                     self.receive_and_feed_counter += 1
 
-                    # }}}
-                # }}}
-                
-                return chunk_number
+                self.receive_and_feed_counter = 0
+                self.receive_and_feed_previous = message
 
-                # }}}
+               # }}}
             else:
-                # {{{ A control chunk has been received
-                print("DBS: Control received")
-                if message == 'H':
-                    if sender not in self.peer_list:
-                        # The peer is new
-                        self.peer_list.append(sender)
-                        self.debt[sender] = 0
-                        print (Color.green, "DBS:", sender, 'added by [hello]', Color.none)
-                else:
-                    if sender in self.peer_list:
-                        sys.stdout.write(Color.red)
-                        print ("DBS:", self.team_socket.getsockname(), '\b: received "goodbye" from', sender)
-                        sys.stdout.write(Color.none)
-                        self.peer_list.remove(sender)
-                        del self.debt[sender]
-                return -1
+                # {{{ The sender is a peer
+
+                # {{{ debug
+
+                if __debug__:
+                    print ("DBS:", self.team_socket.getsockname(), \
+                        Color.green, "<-", Color.none, chunk_number, "-", sender)
 
                 # }}}
+
+                if sender not in self.peer_list:
+                    # The peer is new
+                    self.peer_list.append(sender)
+                    self.debt[sender] = 0
+                    print (Color.green, "DBS:", sender, 'added by chunk', \
+                        chunk_number, Color.none)
+                else:
+                    self.debt[sender] -= 1
+
+                # }}}
+
+            # {{{ A new chunk has arrived and the
+            # previous must be forwarded to next peer of the
+            # list of peers.
+            if ( self.receive_and_feed_counter < len(self.peer_list) and ( self.receive_and_feed_previous != '') ):
+                # {{{ Send the previous chunk in congestion avoiding mode.
+
+                peer = self.peer_list[self.receive_and_feed_counter]
+                self.team_socket.sendto(self.receive_and_feed_previous, peer)
+                self.sendto_counter += 1
+
+                self.debt[peer] += 1
+                if self.debt[peer] > self.MAX_CHUNK_DEBT:
+                    print (Color.red, "DBS:", peer, 'removed by unsupportive (' + str(self.debt[peer]) + ' lossess)', Color.none)
+                    del self.debt[peer]
+                    self.peer_list.remove(peer)
+
+                # {{{ debug
+
+                if __debug__:
+                    print ("DBS:", self.team_socket.getsockname(), "-", \
+                        socket.ntohs(struct.unpack(self.message_format, self.receive_and_feed_previous)[0]),\
+                        Color.green, "->", Color.none, peer)
+
+                # }}}
+
+                self.receive_and_feed_counter += 1
+
+                # }}}
+            # }}}
+
+            return chunk_number
 
             # }}}
-        except socket.timeout:
-            return -2
-        #except socket.error:
-        #    return -3
+        else:
+            # {{{ A control chunk has been received
+            print("DBS: Control received")
+            if message == 'H':
+                if sender not in self.peer_list:
+                    # The peer is new
+                    self.peer_list.append(sender)
+                    self.debt[sender] = 0
+                    print (Color.green, "DBS:", sender, 'added by [hello]', Color.none)
+            else:
+                if sender in self.peer_list:
+                    sys.stdout.write(Color.red)
+                    print ("DBS:", self.team_socket.getsockname(), '\b: received "goodbye" from', sender)
+                    sys.stdout.write(Color.none)
+                    self.peer_list.remove(sender)
+                    del self.debt[sender]
+            return -1
+
+            # }}}
 
         # }}}
 

--- a/src/peer_ims.py
+++ b/src/peer_ims.py
@@ -258,24 +258,32 @@ class Peer_IMS(threading.Thread):
         return message, sender
 
         # }}}
-        
+
     def process_next_message(self):
         # {{{
         try:
-            # {{{ Receive a chunk
+            # {{{ Receive the next message and process it
 
             message, sender = self.receive_the_next_message()
-            chunk_number, chunk = self.unpack_message(message)
-            
-            self.chunks[chunk_number % self.buffer_size] = chunk
-            self.received_flag[chunk_number % self.buffer_size] = True
-            self.received_counter += 1
-
-            return chunk_number
+            # The process_message method can be overridden by inheriting peers
+            return self.process_message(self, message, sender)
 
             # }}}
         except socket.timeout:
             return -2
+
+        # }}}
+
+    def process_message(self, message, sender):
+        # {{{ Receive a chunk
+
+        chunk_number, chunk = self.unpack_message(message)
+
+        self.chunks[chunk_number % self.buffer_size] = chunk
+        self.received_flag[chunk_number % self.buffer_size] = True
+        self.received_counter += 1
+
+        return chunk_number
 
         # }}}
 


### PR DESCRIPTION
Currently, to handle messages of custom format, peers inheriting from Peer_DBS have to copy the `process_next_message(self)` method and adapt it to new messages.
With this change, inheriting peers can override the `process_message(self, message, sender)` method and implement their case differentiation. In case the inheriting class does not handle the received message, the base class method can be called.