### PR TITLE
STrPe-DS testing & some improvements

### DIFF
--- a/src/malicious_peer.py
+++ b/src/malicious_peer.py
@@ -49,9 +49,7 @@ class MaliciousPeer(Peer_DBS):
         # }}}
 
     def listen_to_the_team(self):
-        # {{{ Create "team_socket" (UDP) as a copy of "splitter_socket" (TCP)
-
-        self.team_socket = MaliciousSocket(self.message_format, socket.AF_INET, socket.SOCK_DGRAM)
+        self.team_socket = MaliciousSocket(self.message_format, False, socket.AF_INET, socket.SOCK_DGRAM)
         try:
             # In Windows systems this call doesn't work!
             self.team_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)

--- a/src/malicious_socket.py
+++ b/src/malicious_socket.py
@@ -11,9 +11,10 @@ import struct
 
 class MaliciousSocket():
 
-    def __init__(self, message_format, *p):
+    def __init__(self, message_format, strpeds = False, *p):
         self._sock = socket.socket(*p)
         self.message_format = message_format
+        self.strpeds = strpeds
 
     def sendto(self, string, address):
         if len(string) == struct.calcsize(self.message_format):
@@ -37,5 +38,9 @@ class MaliciousSocket():
         return self._sock.setsockopt(*p)
 
     def get_poisoned_chunk(self, message):
-        chunk_number, chunk = struct.unpack(self.message_format, message)
-        return struct.pack(self.message_format, chunk_number, '0')
+        if self.strpeds:
+            chunk_number, chunk, k1, k2 = struct.unpack(self.message_format, message)
+            return struct.pack(self.message_format, chunk_number, '0', k1, k2)
+        else:
+            chunk_number, chunk = struct.unpack(self.message_format, message)
+            return struct.pack(self.message_format, chunk_number, '0')

--- a/src/peer.py
+++ b/src/peer.py
@@ -138,7 +138,7 @@ class Peer():
             # {{{ This is an "unicast" peer.
 
             peer = Peer_DBS(peer)
-            if args.malicious:
+            if args.malicious and not args.strpeds: # workaround for malicous strpeds peer
                 peer = MaliciousPeer(peer)
             peer.receive_my_endpoint()
             peer.receive_the_number_of_peers()
@@ -167,7 +167,7 @@ class Peer():
             peer = TrustedPeer(peer)
 
         if args.strpeds:
-            peer = Peer_StrpeDs(peer)
+            peer = Peer_StrpeDs(peer, args.malicious)
             peer.receive_dsa_key()
 
         if args.strpe_log != None:

--- a/src/splitter.py
+++ b/src/splitter.py
@@ -135,7 +135,7 @@ class Splitter():
             if (args.strpe):
                 splitter = self.init_strpe_splitter('strpe', args.strpe, args.strpe_log)
             elif (args.strpeds):
-                splitter = self.init_strpe_splitter('strpeds', args.strpeds)
+                splitter = self.init_strpe_splitter('strpeds', args.strpeds, args.strpe_log)
             else:
                 splitter = Splitter_LRS()
 

--- a/src/splitter_strpeds.py
+++ b/src/splitter_strpeds.py
@@ -37,10 +37,8 @@ class StrpeDsSplitter(Splitter_LRS):
         Splitter_LRS.__init__(self)
         self.trusted_peers = []
         self.gathering_counter = 0
+        self.trusted_gathering_counter = 0
         self.gethered_bad_peers = []
-
-    def add_trusted_peer(self, peer):
-        self.trusted_peers.append(peer)
 
     def handle_a_peer_arrival(self, connection):
         serve_socket = connection[0]
@@ -71,12 +69,23 @@ class StrpeDsSplitter(Splitter_LRS):
             if len(self.peer_list) > 0:
                 peer = self.get_peer_for_gathering()
                 self.request_bad_peers(peer) # then, we will handle it in 'moderate the team'
+                time.sleep(2)
+                tp = self.get_trusted_peer_for_gathering()
+                if tp != None:
+                    self.request_bad_peers(tp) # then, we will handle it in 'moderate the team'
+
             time.sleep(self.GATHER_BAD_PEERS_SLEEP)
 
     def get_peer_for_gathering(self):
         self.gathering_counter = (self.gathering_counter + 1) % len(self.peer_list)
         peer = self.peer_list[self.gathering_counter]
         return peer
+
+    def get_trusted_peer_for_gathering(self):
+        self.trusted_gathering_counter = (self.trusted_gathering_counter + 1) % len(self.trusted_peers)
+        if self.trusted_peers[self.trusted_gathering_counter] in self.peer_list:
+            return self.trusted_peers[self.trusted_gathering_counter]
+        return None
 
     def request_bad_peers(self, dest):
         self.team_socket.sendto(b'B', dest)


### PR DESCRIPTION
-It's now possible to test STrPe-DS with testing script:
```./test_strpe.py -n 10 -t 1 -m 2 -s```
`-s` option enables the STrPe-DS mode for peers.

-_malicious_ option for STrPe-DS peers: 
```./peer.py --use_localhost --player_port 10000 --strpeds --malicious```
Malicious STrPe-DS peer sends poisoned chunks.

-Improvement for STrPe-DS splitter: it gathers complains from trusted peers more often.

-Testing script for STrPe mechanism now stops when all malicious peer were excluded from the team (it checks splitter log file every 2 seconds)

-Some refactoring
