### PR TITLE
Added an option to splitter to set the number of monitors.

### DIFF
--- a/src/peer_dbs.py
+++ b/src/peer_dbs.py
@@ -68,7 +68,9 @@ class Peer_DBS(Peer_IMS):
         self.peer_list = [] # The list of peers structure.
 
         sys.stdout.write(Color.green)
-        _print_("DBS: Requesting the number of peers to", self.splitter_socket.getpeername())
+        _print_("DBS: Requesting the number of monitors and peers to", self.splitter_socket.getpeername())
+        self.number_of_monitors = socket.ntohs(struct.unpack("H",self.splitter_socket.recv(struct.calcsize("H")))[0])
+        _print_("DBS: The number of monitors is", self.number_of_monitors)
         self.number_of_peers = socket.ntohs(struct.unpack("H",self.splitter_socket.recv(struct.calcsize("H")))[0])
         _print_("DBS: The size of the team is", self.number_of_peers, "(apart from me)")
 
@@ -336,8 +338,8 @@ class Peer_DBS(Peer_IMS):
 
     def am_i_a_monitor(self):
         # {{{
-        if self.number_of_peers == 0:
-            # Only the first peer of the team is the monitor peer
+        if self.number_of_peers < self.number_of_monitors:
+            # Only the first peers of the team are monitor peers
             return True
         else:
             return False

--- a/src/splitter.py
+++ b/src/splitter.py
@@ -74,6 +74,8 @@ class Splitter():
 
         parser.add_argument('--mcast_addr', help='IP multicast address used to serve the chunks. Makes sense only in multicast mode. Default = "{}".'.format(Splitter_IMS.MCAST_ADDR))
 
+        parser.add_argument('--monitor_number', help='Number of monitors in the team. The first connecting peers will automatically become monitors. Default = "{}".'.format(Splitter_DBS.MONITOR_NUMBER))
+
         parser.add_argument('--port', help='Port to serve the peers. Default = "{}".'.format(Splitter_IMS.PORT))
 
         parser.add_argument('--source_addr', help='IP address or hostname of the streaming server. Default = "{}".'.format(Splitter_IMS.SOURCE_ADDR))

--- a/src/splitter_dbs.py
+++ b/src/splitter_dbs.py
@@ -36,6 +36,7 @@ class Splitter_DBS(Splitter_IMS):
     # }}}
     MAX_CHUNK_LOSS = 32
     MCAST_ADDR = "0.0.0.0"
+    MONITOR_NUMBER = 1
 
     # }}}
 
@@ -81,6 +82,10 @@ class Splitter_DBS(Splitter_IMS):
     def send_the_list_size(self, peer_serve_socket):
         # {{{
 
+        if __debug__:
+            print("DBS: Sending the number of monitors", self.MONITOR_NUMBER)
+        message = struct.pack("H", socket.htons(self.MONITOR_NUMBER))
+        peer_serve_socket.sendall(message)
         if __debug__:
             print("DBS: Sending a list of peers of size", len(self.peer_list))
         message = struct.pack("H", socket.htons(len(self.peer_list)))


### PR DESCRIPTION
This enables the user to set the number of monitors `n`, which are automatically the first `n` peers connecting to the splitter.