### PR TITLE
Adapted Splitter_DBS to fully use the number of monitors option.

### DIFF
--- a/src/splitter.py
+++ b/src/splitter.py
@@ -101,6 +101,9 @@ class Splitter():
         if args.header_size:
             Splitter_IMS.HEADER_SIZE = int(args.header_size)
 
+        if args.monitor_number:
+            Splitter_DBS.MONITOR_NUMBER = int(args.monitor_number)
+
         if args.port:
             Splitter_IMS.PORT = int(args.port)
 

--- a/src/splitter_dbs.py
+++ b/src/splitter_dbs.py
@@ -236,7 +236,7 @@ class Splitter_DBS(Splitter_IMS):
                 print("DBS: ", peer, "has loss", self.losses[peer], "chunks")
                 sys.stdout.write(Color.none)
             if self.losses[peer] > self.MAX_CHUNK_LOSS:
-                if peer != self.peer_list[0]:
+                if peer not in self.peer_list[0:self.MONITOR_NUMBER]:
                     sys.stdout.write(Color.red)
                     print("DBS: ", peer, 'removed')
                     self.remove_peer(peer)
@@ -257,7 +257,7 @@ class Splitter_DBS(Splitter_IMS):
             print("DBS: ", sender, "complains about lost chunk", lost_chunk_number, "sent to", destination)
             sys.stdout.write(Color.none)
 
-            if destination == self.peer_list[0]:
+            if destination in self.peer_list[0:self.MONITOR_NUMBER]:
                 print ("DBS: lost chunk index =", lost_chunk_number)
 
         self.increment_unsupportivity_of_peer(destination)
@@ -272,7 +272,7 @@ class Splitter_DBS(Splitter_IMS):
         sys.stdout.write(Color.none)
         sys.stdout.flush()
 
-        #if peer != self.peer_list[0]:
+        #if peer not in self.peer_list[0:self.MONITOR_NUMBER]:
         self.remove_peer(peer)
 
         # }}}

--- a/src/splitter_dbs.py
+++ b/src/splitter_dbs.py
@@ -236,7 +236,7 @@ class Splitter_DBS(Splitter_IMS):
                 print("DBS: ", peer, "has loss", self.losses[peer], "chunks")
                 sys.stdout.write(Color.none)
             if self.losses[peer] > self.MAX_CHUNK_LOSS:
-                if peer not in self.peer_list[0:self.MONITOR_NUMBER]:
+                if peer not in self.peer_list[:self.MONITOR_NUMBER]:
                     sys.stdout.write(Color.red)
                     print("DBS: ", peer, 'removed')
                     self.remove_peer(peer)
@@ -257,7 +257,7 @@ class Splitter_DBS(Splitter_IMS):
             print("DBS: ", sender, "complains about lost chunk", lost_chunk_number, "sent to", destination)
             sys.stdout.write(Color.none)
 
-            if destination in self.peer_list[0:self.MONITOR_NUMBER]:
+            if destination in self.peer_list[:self.MONITOR_NUMBER]:
                 print ("DBS: lost chunk index =", lost_chunk_number)
 
         self.increment_unsupportivity_of_peer(destination)
@@ -272,7 +272,7 @@ class Splitter_DBS(Splitter_IMS):
         sys.stdout.write(Color.none)
         sys.stdout.flush()
 
-        #if peer not in self.peer_list[0:self.MONITOR_NUMBER]:
+        #if peer not in self.peer_list[:self.MONITOR_NUMBER]:
         self.remove_peer(peer)
 
         # }}}


### PR DESCRIPTION
To determine if a given peer is a monitor peer, now you have to check not only the first peer `self.peer_list[0]` but the first number of peers `self.peer_list[0:self.MONITOR_NUMBER]`.
This is an addition to #64.