### PR TITLE
Python3 fixes for NTS and test scripts; improved inheritance technique

### DIFF
--- a/doc/NTS/NAT_traversal.md
+++ b/doc/NTS/NAT_traversal.md
@@ -228,7 +228,7 @@ position in the team of the peer that does the port prediction).
     # Influence the prediction to achieve the desired number of results
     count_factor = common.MAX_PREDICTED_PORTS/float(num_combinations)
 
-    port_diffs = functools.sorted(set(reduce(list.__add__, (list(
+    port_diffs = sorted(set(functools.reduce(list.__add__, (list(
         # For each previous peer and each skip, the source port is incremented
         port_step * (peer_number + skips)
         # For each assumed port_step, "port_diff/port_step" different port skips

--- a/doc/NTS/NAT_traversal.md
+++ b/doc/NTS/NAT_traversal.md
@@ -228,7 +228,7 @@ position in the team of the peer that does the port prediction).
     # Influence the prediction to achieve the desired number of results
     count_factor = common.MAX_PREDICTED_PORTS/float(num_combinations)
 
-    port_diffs = sorted(set(reduce(list.__add__, (list(
+    port_diffs = functools.sorted(set(reduce(list.__add__, (list(
         # For each previous peer and each skip, the source port is incremented
         port_step * (peer_number + skips)
         # For each assumed port_step, "port_diff/port_step" different port skips

--- a/src/core/peer_nts.py
+++ b/src/core/peer_nts.py
@@ -27,7 +27,6 @@ from core.color import Color
 from core.common import Common
 from core._print_ import _print_
 from core.peer_dbs import Peer_DBS
-from core.symsp_peer import Symsp_Peer
 from core.symsp_socket import symsp_socket
 
 # }}}
@@ -272,13 +271,7 @@ class Peer_NTS(Peer_DBS):
                 # Recreate the socket
                 # Similar to Peer_DBS.listen_to_the_team, binds to a random port
                 self.team_socket.close()
-                if Symsp_Peer.PORT_STEP:
-                    self.team_socket = symsp_socket(Symsp_Peer.PORT_STEP,
-                                                    socket.AF_INET,
-                                                    socket.SOCK_DGRAM)
-                else:
-                    self.team_socket = socket.socket(socket.AF_INET,
-                                                     socket.SOCK_DGRAM)
+                self.create_team_socket()
                 try:
                     self.team_socket.setsockopt(socket.SOL_SOCKET,
                                                 socket.SO_REUSEADDR, 1)

--- a/src/core/peer_nts.py
+++ b/src/core/peer_nts.py
@@ -14,6 +14,7 @@ peer_nts module
 
 # {{{
 
+import functools
 import math
 import threading
 import time
@@ -313,7 +314,7 @@ class Peer_NTS(Peer_DBS):
     def get_factors(self, n):
         # {{{ This function is from http://stackoverflow.com/a/6800214
 
-        return sorted(set(reduce(list.__add__,
+        return sorted(set(functools.reduce(list.__add__,
                                  ([i, n//i] for i in \
                                   range(1, int(n**0.5) + 1) if n % i == 0))))
 
@@ -327,7 +328,7 @@ class Peer_NTS(Peer_DBS):
         # Example: the number is 10, the factors are 1, 2, 5, 10.
         # Products <=10: 1*1, ..., 1*10, 2*1, ..., 2*5, 5*1, 5*2, 10*1.
         # So for each factor there are "n/factor" products:
-        return reduce(lambda a, b: a + b, factors)
+        return functools.reduce(lambda a, b: a + b, factors)
 
         # }}}
 
@@ -344,7 +345,7 @@ class Peer_NTS(Peer_DBS):
         num_combinations = self.count_combinations(factors)
         count_factor = Common.MAX_PREDICTED_PORTS/float(num_combinations)
 
-        port_diffs = sorted(set(reduce(list.__add__, (list(
+        port_diffs = functools.sorted(set(reduce(list.__add__, (list(
             # For each previous peer and skip, the source port is incremented
             port_step * (peer_number + skips)
             # For each assumed port_step, "port_diff/port_step" different skips

--- a/src/core/symsp_peer.py
+++ b/src/core/symsp_peer.py
@@ -35,23 +35,11 @@ class Symsp_Peer(Peer_DBS):
 
         # }}}
 
-    def listen_to_the_team(self):
-        # {{{ Create "team_socket" (UDP) as a copy of "splitter_socket" (TCP)
+    def create_team_socket(self):
+        # {{{ Create "team_socket" (UDP)
 
         # Create a special socket to force source port increment on SYMSP NATs
-        self.team_socket = symsp_socket(self.PORT_STEP, socket.AF_INET,
-                                        socket.SOCK_DGRAM)
-        try:
-            # In Windows systems this call doesn't work!
-            self.team_socket.setsockopt( \
-                socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        except Exception as e:
-            print ("NTS:", e)
-        self.team_socket.bind(('', self.splitter_socket.getsockname()[PORT]))
-
-        # This is the maximum time the peer will wait for a chunk
-        # (from the splitter or from another peer).
-        self.team_socket.settimeout(1)
+        self.team_socket = symsp_socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
 
         # }}}
 

--- a/src/peer.py
+++ b/src/peer.py
@@ -135,12 +135,13 @@ class Peer():
 
         if args.show_buffer:
             Peer_IMS.SHOW_BUFFER = True
-        
+
         # A multicast address is always received, even for DBS peers.
         if peer.mcast_addr == "0.0.0.0":
             # {{{ IP unicast mode.
 
             peer = Peer_DBS(peer)
+            _print_("Peer DBS enabled")
             peer.receive_my_endpoint()
             peer.receive_magic_flags()
             _print_("Magic flags =", bin(peer.magic_flags))
@@ -161,23 +162,24 @@ class Peer():
                 # The peer is a monitor. Now it's time to know the sets of rules that control this team.
 
                 if (peer.magic_flags & Common.LRS):
+                    peer = Peer_LRS(peer)
+                    _print_("Peer LRS enabled")
                     peer = Monitor_LRS(peer)
                     _print_("Monitor LRS enabled")
                 if (peer.magic_flags & Common.NTS):
+                    peer = Peer_NTS(peer)
+                    _print_("Peer NTS enabled")
                     peer = Monitor_NTS(peer)
                     _print_("Monitor NTS enabled")
             else:
-                peer = Peer_DBS(peer)
-                _print_("Peer DBS enabled")
-
                 # The peer is a normal peer. Let's know the sets of rules that control this team.
-                
+
                 if (peer.magic_flags & Common.NTS):
                     peer = Peer_NTS(peer)
                     _print_("Peer NTS enabled")
 
                 if args.enable_chunk_loss:
-                
+
                     if args.chunk_loss_period:
                         Lossy_Peer.CHUNK_LOSS_PERIOD = int(args.chunk_loss_period)
                         print('CHUNK_LOSS_PERIOD =', Lossy_Peer.CHUNK_LOSS_PERIOD)
@@ -234,6 +236,7 @@ class Peer():
 
         # }}}
 
+        print("Created new peer of type %s\n" % peer.__class__.__name__)
 
         # {{{ Run!
 

--- a/src/tools/cleanup_NAT_network.sh
+++ b/src/tools/cleanup_NAT_network.sh
@@ -6,7 +6,7 @@ BRIDGES="brnet1 brinet brnet2"
 # Cleanup
 echo "Cleaning up"
 killall sshd
-pkill -f 'python2 -u'
+pkill -f 'python3 -u'
 for NAMESPACE in $NAMESPACES; do
     ip netns delete $NAMESPACE
 done

--- a/src/tools/setup_NAT_network.sh
+++ b/src/tools/setup_NAT_network.sh
@@ -79,3 +79,6 @@ done
 # Configure packet forwarding
 ip netns exec nat1 sysctl net.ipv4.ip_forward=1
 ip netns exec nat2 sysctl net.ipv4.ip_forward=1
+# Initial NAT settings
+ip netns exec nat1 iptables-restore /etc/iptables/iptables.rules.prcn1
+ip netns exec nat2 iptables-restore /etc/iptables/iptables.rules.prcn2

--- a/src/tools/test_NAT_traversal.sh
+++ b/src/tools/test_NAT_traversal.sh
@@ -28,7 +28,7 @@ nat2_pub="192.168.57.5"
 function stop_processes() {
     set +e
     for host in $splitter $pc1 $pc2; do
-        ssh "$user@$host" "pkill -f 'python2 -u $dir'" 2>/dev/null
+        ssh "$user@$host" "pkill -f 'python3 -u $dir'" 2>/dev/null
     done
     killall vlc 2>/dev/null
     killall netcat 2>/dev/null
@@ -83,13 +83,13 @@ $nat1_config "
             # parameters: splitter_port, peer_port, player_port
 
             # Run splitter
-            ssh "$user@$splitter" python2 -u "$dir/splitter.py" --source_addr "$local_source_addr" \
+            ssh "$user@$splitter" python3 -u "$dir/splitter.py" --source_addr "$local_source_addr" \
                 --source_port "$local_source_port" --port "$splitter_port" >/dev/null &
 
             # Run monitor on same host as splitter
-            peer_cmd="python2 -u $dir/peer.py --splitter_addr '$splitter' --player_port '$3' \
+            peer_cmd="python3 -u $dir/peer.py --splitter_addr '$splitter' --player_port '$3' \
                 --splitter_port '$1' --port '$2' | sed 's_[^m]*m__g'"
-            peer_cmd_symsp="python2 -u $dir/peer.py --splitter_addr '$splitter' --player_port '$3' \
+            peer_cmd_symsp="python3 -u $dir/peer.py --splitter_addr '$splitter' --player_port '$3' \
                 --splitter_port '$1' --port '$2' --port_step 1 | sed 's_[^m]*m__g'"
             ssh "$user@$splitter" "$peer_cmd" >/dev/null &
 

--- a/src/tools/test_NAT_traversal.sh
+++ b/src/tools/test_NAT_traversal.sh
@@ -83,8 +83,8 @@ $nat1_config "
             # parameters: splitter_port, peer_port, player_port
 
             # Run splitter
-            ssh "$user@$splitter" python3 -u "$dir/splitter.py" --source_addr "$local_source_addr" \
-                --source_port "$local_source_port" --port "$splitter_port" >/dev/null &
+            ssh "$user@$splitter" python3 -u "$dir/splitter.py" --NTS --source_addr "$local_source_addr" \
+                --source_port "$local_source_port" --channel "$source_filename" --port "$splitter_port" >/dev/null &
 
             # Run monitor on same host as splitter
             peer_cmd="python3 -u $dir/peer.py --splitter_addr '$splitter' --player_port '$3' \
@@ -122,8 +122,8 @@ $nat1_config "
         for sequential_run in $(seq $sequential_runs); do
             date
             # Run stream source
-            cvlc --sout "#duplicate{dst=standard{mux=ogg,dst=:$local_source_port,access=http}}" \
-                "$source_filename" 2>/dev/null &
+            cvlc --sout "#duplicate{dst=standard{mux=ogg,dst=:/$source_filename,access=http}}" \
+                "$source_filename" --http-port "$local_source_port" 2>/dev/null &
             sleep 1
             player_port=$((splitter_port+(parallel_runs*testruns)))
             for parallel_run in $(seq $parallel_runs); do

--- a/src/tools/testrun.sh
+++ b/src/tools/testrun.sh
@@ -19,7 +19,7 @@ else
     export splitter_port
     export peer_port
 
-    ./testrun2.sh
+    ./src/tools/testrun2.sh
     # Record a testrun:
     # asciinema rec -c ./testrun2.sh asciinema.txt
 fi

--- a/src/tools/testrun2.sh
+++ b/src/tools/testrun2.sh
@@ -42,23 +42,23 @@ ssh $user@$server python3 -u $dir/peer.py --splitter_addr "$splitter" \
     --splitter_port "$splitter_port" --port "$peer_port" \
     | sed -n -e 's_.*NTS:\(.*\)_\x1b[96mMonitor2:\1\x1b[0m_p' &
 ssh $user@$pc1 python3 -u $dir/peer.py --splitter_addr "$splitter" \
-    --splitter_port "$splitter_port" --port "$peer_port" --port_step 1 & \
-    #| sed -n -e 's_.*NTS:\(.*\)_\x1b[94mPeer1:   \1\x1b[0m_p' &
-#~ ssh $user@$pc2 python3 -u $dir/peer.py --splitter_addr "$splitter" \
-    #~ --splitter_port "$splitter_port" --port "$peer_port" --port_step 1 \
-    #~ | sed -n -e 's_.*NTS:\(.*\)_\x1b[95mPeer2:   \1\x1b[0m_p' &
+    --splitter_port "$splitter_port" --port "$peer_port" --port_step 1 \
+    | sed -n -e 's_.*NTS:\(.*\)_\x1b[94mPeer1:   \1\x1b[0m_p' &
+ssh $user@$pc2 python3 -u $dir/peer.py --splitter_addr "$splitter" \
+    --splitter_port "$splitter_port" --port "$peer_port" --port_step 1 \
+    | sed -n -e 's_.*NTS:\(.*\)_\x1b[95mPeer2:   \1\x1b[0m_p' &
 sleep 2
-vlc "http://$splitter:9999" &
+cvlc "http://$splitter:9999" --vout none --aout none 2>/dev/null &
 id0=$!
 sleep 1
-vlc "http://$server:9999" &
+cvlc "http://$server:9999" --vout none --aout none 2>/dev/null &
 id1=$!
 sleep 1
-vlc "http://$pc1:9999" &
+cvlc "http://$pc1:9999" --vout none --aout none 2>/dev/null &
 id2=$!
-#~ sleep 1
-#~ cvlc "http://$pc2:9999" --vout none --aout none 2>/dev/null &
-#~ id3=$!
+sleep 1
+cvlc "http://$pc2:9999" --vout none --aout none 2>/dev/null &
+id3=$!
 sleep 20
 set +e
 kill $id0

--- a/src/tools/testrun2.sh
+++ b/src/tools/testrun2.sh
@@ -18,7 +18,7 @@ local_source_addr=192.168.57.1
 set -e
 function stop_processes() {
     for host in $splitter $server $pc1 $pc2; do
-        ssh $user@$host 'pkill -f "python2 -u"'
+        ssh $user@$host 'pkill -f "python3 -u"'
     done
 }
 # Register cleanup trap function
@@ -28,19 +28,21 @@ trap stop_processes EXIT
 ssh "root@192.168.56.5" "conntrack -F" 2>/dev/null
 ssh "root@192.168.58.4" "conntrack -F" 2>/dev/null
 
-ssh $user@$splitter python2 -u "$dir/splitter.py" --source_addr "$local_source_addr" \
-    --source_port "4551"  --port "$splitter_port" --monitor_number 2 \
-    | sed -n -e 's_.*NTS:\(.*\)_\x1b[93mSplitter:\1\x1b[0m_p' &
-ssh $user@$splitter python2 -u $dir/peer.py --splitter_addr "$splitter" \
+ssh $user@$splitter python3 -u "$dir/splitter.py" --source_addr "$local_source_addr" \
+    --source_port "8080"  --port "$splitter_port" --NTS &
+    #~ | sed -n -e 's_.*NTS:\(.*\)_\x1b[93mSplitter:\1\x1b[0m_p' &
+sleep 10
+echo continue
+ssh $user@$splitter python3 -u $dir/peer.py --splitter_addr "$splitter" \
     --splitter_port "$splitter_port" --port "$peer_port" \
     | sed -n -e 's_.*NTS:\(.*\)_\x1b[92mMonitor1:\1\x1b[0m_p' &
-ssh $user@$server python2 -u $dir/peer.py --splitter_addr "$splitter" \
-    --splitter_port "$splitter_port" --port "$peer_port" \
-    | sed -n -e 's_.*NTS:\(.*\)_\x1b[96mMonitor2:\1\x1b[0m_p' &
-ssh $user@$pc1 python2 -u $dir/peer.py --splitter_addr "$splitter" \
+#ssh $user@$server python3 -u $dir/peer.py --splitter_addr "$splitter" \
+#    --splitter_port "$splitter_port" --port "$peer_port" \
+#    | sed -n -e 's_.*NTS:\(.*\)_\x1b[96mMonitor2:\1\x1b[0m_p' &
+ssh $user@$pc1 python3 -u $dir/peer.py --splitter_addr "$splitter" \
     --splitter_port "$splitter_port" --port "$peer_port" --port_step 1 \
     | sed -n -e 's_.*NTS:\(.*\)_\x1b[94mPeer1:   \1\x1b[0m_p' &
-ssh $user@$pc2 python2 -u $dir/peer.py --splitter_addr "$splitter" \
+ssh $user@$pc2 python3 -u $dir/peer.py --splitter_addr "$splitter" \
     --splitter_port "$splitter_port" --port "$peer_port" --port_step 1 \
     | sed -n -e 's_.*NTS:\(.*\)_\x1b[95mPeer2:   \1\x1b[0m_p' &
 sleep 1

--- a/src/tools/testrun2.sh
+++ b/src/tools/testrun2.sh
@@ -14,6 +14,8 @@ server="192.168.57.7"
 nat1_pub="192.168.57.4"
 nat2_pub="192.168.57.5"
 local_source_addr=192.168.57.1
+local_source_port=8080
+src_channel="Big_Buck_Bunny_small.ogv"
 
 set -e
 function stop_processes() {
@@ -25,38 +27,38 @@ function stop_processes() {
 trap stop_processes EXIT
 
 # Clear NAT mappings
-ssh "root@192.168.56.5" "conntrack -F" 2>/dev/null
-ssh "root@192.168.58.4" "conntrack -F" 2>/dev/null
+#ssh "root@192.168.56.5" "conntrack -F" 2>/dev/null
+#ssh "root@192.168.58.4" "conntrack -F" 2>/dev/null
 
 ssh $user@$splitter python3 -u "$dir/splitter.py" --source_addr "$local_source_addr" \
-    --source_port "8080"  --port "$splitter_port" --NTS &
-    #~ | sed -n -e 's_.*NTS:\(.*\)_\x1b[93mSplitter:\1\x1b[0m_p' &
-sleep 10
-echo continue
+    --source_port "$local_source_port" --channel "$src_channel" --port "$splitter_port" \
+    --NTS --max_number_of_monitor_peers 1 \
+    | sed -n -e 's_.*NTS:\(.*\)_\x1b[93mSplitter:\1\x1b[0m_p' &
+sleep 2
 ssh $user@$splitter python3 -u $dir/peer.py --splitter_addr "$splitter" \
     --splitter_port "$splitter_port" --port "$peer_port" \
     | sed -n -e 's_.*NTS:\(.*\)_\x1b[92mMonitor1:\1\x1b[0m_p' &
-#ssh $user@$server python3 -u $dir/peer.py --splitter_addr "$splitter" \
-#    --splitter_port "$splitter_port" --port "$peer_port" \
-#    | sed -n -e 's_.*NTS:\(.*\)_\x1b[96mMonitor2:\1\x1b[0m_p' &
+ssh $user@$server python3 -u $dir/peer.py --splitter_addr "$splitter" \
+    --splitter_port "$splitter_port" --port "$peer_port" \
+    | sed -n -e 's_.*NTS:\(.*\)_\x1b[96mMonitor2:\1\x1b[0m_p' &
 ssh $user@$pc1 python3 -u $dir/peer.py --splitter_addr "$splitter" \
-    --splitter_port "$splitter_port" --port "$peer_port" --port_step 1 \
-    | sed -n -e 's_.*NTS:\(.*\)_\x1b[94mPeer1:   \1\x1b[0m_p' &
-ssh $user@$pc2 python3 -u $dir/peer.py --splitter_addr "$splitter" \
-    --splitter_port "$splitter_port" --port "$peer_port" --port_step 1 \
-    | sed -n -e 's_.*NTS:\(.*\)_\x1b[95mPeer2:   \1\x1b[0m_p' &
-sleep 1
-cvlc "http://$splitter:9999" --vout none --aout none 2>/dev/null &
+    --splitter_port "$splitter_port" --port "$peer_port" --port_step 1 & \
+    #| sed -n -e 's_.*NTS:\(.*\)_\x1b[94mPeer1:   \1\x1b[0m_p' &
+#~ ssh $user@$pc2 python3 -u $dir/peer.py --splitter_addr "$splitter" \
+    #~ --splitter_port "$splitter_port" --port "$peer_port" --port_step 1 \
+    #~ | sed -n -e 's_.*NTS:\(.*\)_\x1b[95mPeer2:   \1\x1b[0m_p' &
+sleep 2
+vlc "http://$splitter:9999" &
 id0=$!
 sleep 1
-cvlc "http://$server:9999" --vout none --aout none 2>/dev/null &
+vlc "http://$server:9999" &
 id1=$!
 sleep 1
-cvlc "http://$pc1:9999" --vout none --aout none 2>/dev/null &
+vlc "http://$pc1:9999" &
 id2=$!
-sleep 1
-cvlc "http://$pc2:9999" --vout none --aout none 2>/dev/null &
-id3=$!
+#~ sleep 1
+#~ cvlc "http://$pc2:9999" --vout none --aout none 2>/dev/null &
+#~ id3=$!
 sleep 20
 set +e
 kill $id0


### PR DESCRIPTION
This set of commits fixes Python3 support for NTS classes and the respective scripts.
It also improves the inheritance technique implemented in P2PSP: When a peer is instantiated, for each layer a temporary subclass with the required base class and methods is created, e.g. `Peer_IMS.Peer_DBS.Monitor_DBS.Peer_NTS.Monitor_NTS`.