### PR TITLE
Remove peer properly when peer exceeds max chunk loss.

### DIFF
--- a/src/core/splitter_dbs.cc
+++ b/src/core/splitter_dbs.cc
@@ -155,12 +155,8 @@ void SplitterDBS::IncrementUnsupportivityOfPeer(
     TRACE("" << peer << " has lost " << to_string(losses_[peer]) << " chunks");
 
     if (losses_[peer] > max_chunk_loss_) {
-      // TODO: Check this condition in original code, is it correct?
-      if (find(peer_list_.begin(), peer_list_.begin() + monitor_number_,
-               peer) == peer_list_.end()) {
         TRACE("" << peer << " removed");
         RemovePeer(peer);
-      }
     }
   }
 }


### PR DESCRIPTION
The present condition always returns `false` and has several issues

-  `find` will return `peer_list_.begin() + monitor_number_` and not `peer_list_.end()` if the element is not found.`
- checks only for monitors?

The solution is to remove it since we anyways check inside `RemovePeer` or correct it to
`find(peer_list_.begin() + monitor_number_,peer_list_.end(), peer) == peer_list_.end()`

This is an attempt to fix #85
