### PR TITLE
Exit from splitter when address already in use while binding.

### DIFF
--- a/src/core/splitter_ims.cc
+++ b/src/core/splitter_ims.cc
@@ -61,9 +61,9 @@ void SplitterIMS::SetupPeerConnectionSocket() {
 void SplitterIMS::ConfigureSockets() {
   try {
     SetupPeerConnectionSocket();
-  } catch (int e) {
-    TRACE(e);
-    TRACE(peer_connection_socket_.local_endpoint().address().to_string() +
+  } catch (system::system_error &error) {
+    TRACE(error.what());
+    TRACE(acceptor_.local_endpoint().address().to_string() +
           "\b: unable to bind the port " + to_string(port_));
     exit(-1);
   }


### PR DESCRIPTION
The exception from `boost::asio::ip` (`SIGABRT`) was not being caught by the catch block, hence core dumped was produced.

Attempts to fix #83.