### PR TITLE
Dynamically select Sets of Rules at splitter

### DIFF
--- a/src/core/common.h
+++ b/src/core/common.h
@@ -12,6 +12,7 @@
 #define P2PSP_CORE_COMMON_H
 
 #include <openssl/sha.h>
+#include <vector>
 
 namespace p2psp {
 
@@ -40,6 +41,7 @@ class Common {
   static const char kLRS = 2;  // LRS magic number
   static const char kNTS = 4;  // NIS magic number
   static const char kDIS = 8;  // DIS magic number
+  static const char kSTRPE= 16;  // STRPE magic number
 
   // TODO: Use colors
   // IMS_COLOR = Color.red

--- a/src/core/splitter_dbs.cc
+++ b/src/core/splitter_dbs.cc
@@ -33,6 +33,10 @@ SplitterDBS::SplitterDBS() : SplitterIMS(), losses_(0, &SplitterDBS::GetHash) {
 
 SplitterDBS::~SplitterDBS() {}
 
+char SplitterDBS::GetMagicFlags() {
+  return magic_flags_;
+}
+
 void SplitterDBS::SendMagicFlags(
     const std::shared_ptr<boost::asio::ip::tcp::socket> &peer_serve_socket) {
   char message[1];

--- a/src/core/splitter_dbs.h
+++ b/src/core/splitter_dbs.h
@@ -57,11 +57,12 @@ class SplitterDBS : public SplitterIMS {
     stream << endpoint;
     std::hash<std::string> hasher;
     return hasher(stream.str());
-  }; 
+  };
 
  public:
   SplitterDBS();
   ~SplitterDBS();
+  char GetMagicFlags();
   void SendMagicFlags(
       const std::shared_ptr<boost::asio::ip::tcp::socket> &peer_serve_socket);
   void SendTheListSize(

--- a/src/core/splitter_strpe.cc
+++ b/src/core/splitter_strpe.cc
@@ -16,6 +16,7 @@ using namespace boost;
 
 SplitterSTRPE::SplitterSTRPE()
     : SplitterLRS(), logging_(kLogging), current_round_(kCurrentRound) {
+  magic_flags_ = Common::kSTRPE;
   LOG("STrPe");
 }
 


### PR DESCRIPTION
This commit enables the splitter to create the splitter instance depending on the runtime flags.
For Set-of-Rule-dependent parameters, checking and casting to the needed subclass is done.
EDIT: If you planned or already started a different implementation, just drop a comment.