### PR TITLE
test_UDP.py output slightly changed to be more accurate

### DIFF
--- a/src/tools/test_UDP.py
+++ b/src/tools/test_UDP.py
@@ -56,13 +56,13 @@ class Packets_per_second(Thread):
     def run(self):
         global sent_packets
         global last_sent
-        iters = 1
+        iters = 0
         while True:
+            time.sleep(1)
+            iters += 1
             last_sent = sent_packets - last_sent
             print str(last_sent*payload_size*8/1000) + " Kbps" + " ( average = " + str(sent_packets*payload_size*8/(iters*1000)) + " Kbps )"
             last_sent = sent_packets
-            time.sleep(1)
-            iters += 1
 
 pack = Packets_per_second()
 pack.daemon = True


### PR DESCRIPTION
Previous version was calculating average speed incorrect, because the first value was always zero and therefore average amount is always understated
> 0 Kbps ( average = 0 Kbps )
1446068 Kbps ( average = 723054 Kbps )
1440088 Kbps ( average = 962068 Kbps )
1445511 Kbps ( average = 1082931 Kbps )
1432338 Kbps ( average = 1152814 Kbps )
1441701 Kbps ( average = 1200963 Kbps )

I have just changed few lines and currently it is working correctly
> 1470857 Kbps ( average = 1470857 Kbps )
1438072 Kbps ( average = 1454473 Kbps )
1439735 Kbps ( average = 1449563 Kbps )
1461444 Kbps ( average = 1452535 Kbps )
1442185 Kbps ( average = 1450467 Kbps )
1455923 Kbps ( average = 1451378 Kbps )

I am trying to get used to the code base for GSoC, so I thought that fixing some minor bugs would be useful.