### PR TITLE
Fixed proper exit of a peer after removal from peer_list

### DIFF
--- a/src/core/peer_ims.py
+++ b/src/core/peer_ims.py
@@ -476,8 +476,11 @@ class Peer_IMS(threading.Thread):
         #    if chunk_number >= 0:
         #        break
         chunk_number = self.process_next_message()
+        current_time=time.time()
         while chunk_number < 0:
             chunk_number = self.process_next_message()
+            if((time.time()-current_time)>15):
+                return -2
         #while ((chunk_number - self.played_chunk) % self.buffer_size) < self.buffer_size/2:
         while self.received_counter < self.buffer_size/2:
             chunk_number = self.process_next_message()
@@ -502,8 +505,10 @@ class Peer_IMS(threading.Thread):
         #threading.Thread(target=self.play).start()
 
         while self.player_alive:
-            self.keep_the_buffer_full()
+            status=self.keep_the_buffer_full()
             self.play_next_chunk()
+            if(status==-2):
+                return
 
         # }}}
 


### PR DESCRIPTION
We receive a negative chunk number whenever there is a socket timeout (process_next_message() function). However in line 479, we keep on waiting for the chunks whenever there is a negative chunk number.
If the splitter removes a particular peer from the peer_list, the splitter no longer sends the chunks to the peer , so do the other peers.
Also, since this is a UDP socket, there might be packet losses.

Hence, technically the peer will never get to know if the socket timeout is because of UDP or because it was removed from the peer_list.

One way to resolve this issue is to wait for a certain amount of time before stopping the peer thread.
I have chosen this time interval as 15 seconds. This can be modified as required.
