### PR TITLE
Insert pre-existing peers at the end of peer list

### DIFF
--- a/src/core/splitter_dbs.cc
+++ b/src/core/splitter_dbs.cc
@@ -100,10 +100,10 @@ void SplitterDBS::SendConfiguration(
 }
 
 void SplitterDBS::InsertPeer(const boost::asio::ip::udp::endpoint &peer) {
-  if (find(peer_list_.begin(), peer_list_.end(), peer) == peer_list_.end()) {
-    peer_list_.push_back(peer);
+  if (find(peer_list_.begin(), peer_list_.end(), peer) != peer_list_.end()) {
+    peer_list_.erase(find(peer_list_.begin(), peer_list_.end(), peer));
   }
-
+  peer_list_.push_back(peer);
   losses_[peer] = 0;
   TRACE("Inserted peer " << peer);
 }


### PR DESCRIPTION
When a new connection arrives, if the connection is from an existing peer in the `peer_list_` comes then only it's 'losses_' is being set to zero. But, its position on the 'peer_list_' remains same. This causes an indifference between pre-existing and new-coming peers while calculating `ComputeNextPeerNumber`. They should actually be treated like a new-coming peer always even if it does exist on the `peer_list_` before.